### PR TITLE
Return correct error instead of panicking if requested `resolc` version doesn't exist

### DIFF
--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -425,7 +425,7 @@ fn compile_output(output: Output) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
-#[cfg(any(feature = "full"))]
+#[cfg(feature = "full")]
 mod test {
     use foundry_compilers_core::error::SolcError;
 

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -150,7 +150,7 @@ impl Resolc {
                                 .map_err(|e| SolcError::Message(e.to_string()))?
                         } else {
                             version_manager
-                                .get_or_install(&resolc_version, _solc_version.clone())
+                                .get_or_install(resolc_version, _solc_version.clone())
                                 .map_err(|e| SolcError::Message(e.to_string()))?
                         }
                     } else {
@@ -470,7 +470,7 @@ mod test {
         .expect_err("should fail");
         assert_eq!(
             result.to_string(), 
-            "Unsupported version of `solc` - v0.4.14 for Resolc v0.1.0-dev.13. Only versions \">=0.8.0, <=0.8.29\" is supported by this version of Resolc",
+            "Unsupported version of `solc` - v0.4.14 for Resolc v0.1.0-dev.13. Only versions \">=0.8.0, <=0.8.29\" is supported by this version of Resolc"
         )
     }
 }

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -153,7 +153,7 @@ impl Resolc {
                     let message = if let Some(v) = &_resolc_version {
                         format!("`resolc` v{v} doesn't exist")
                     } else {
-                        format!("No `resolc` versions available.")
+                        "No `resolc` versions available.".to_string()
                     };
                     return Err(SolcError::Message(message));
                 };
@@ -353,7 +353,9 @@ impl Resolc {
             cmd.arg(&solc.solc);
             cmd.arg("--standard-json");
             let mut child = cmd.spawn().map_err(map_io_err(&self.resolc))?;
-            let mut stdin = io::BufWriter::new(child.stdin.take().unwrap());
+            let mut stdin = io::BufWriter::new(
+                child.stdin.take().ok_or(SolcError::msg("`resolc` `stdin` closed"))?,
+            );
             serde_json::to_writer(&mut stdin, &input)?;
             stdin.flush().map_err(map_io_err(&self.resolc))?;
             child

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -251,7 +251,6 @@ impl Resolc {
                     .list_available(_solc_version.clone())
                     .map_err(|e| SolcError::Message(e.to_string()))?
                     .into_iter()
-                    .filter(|x| _resolc_version.is_none_or(|version| version == x.version()))
                     .collect();
 
                 versions.into_iter().next_back()

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -469,7 +469,7 @@ mod test {
         )
         .expect_err("should fail");
         assert_eq!(
-            result.to_string(), 
+            result.to_string(),
             "Unsupported version of `solc` - v0.4.14 for Resolc v0.1.0-dev.13. Only versions \">=0.8.0, <=0.8.29\" is supported by this version of Resolc"
         )
     }

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -423,3 +423,23 @@ fn compile_output(output: Output) -> Result<Vec<u8>> {
         Err(SolcError::solc_output(&output))
     }
 }
+
+#[cfg(test)]
+#[cfg(any(feature = "full"))]
+mod test {
+    use foundry_compilers_core::error::SolcError;
+
+    use super::Resolc;
+
+    #[test]
+    fn not_existing_version() {
+        let result = Resolc::install(
+            semver::Version::parse("0.1.0-dev.33").ok().as_ref(),
+            crate::solc::SolcCompiler::AutoDetect,
+        )
+        .expect_err("should fail");
+        assert!(
+            matches!(result, SolcError::Message(msg) if msg == "`resolc` v0.1.0-dev.33 doesn't exist")
+        )
+    }
+}

--- a/crates/compilers/src/compilers/resolc/compiler.rs
+++ b/crates/compilers/src/compilers/resolc/compiler.rs
@@ -149,7 +149,14 @@ impl Resolc {
                     .filter(|x| _resolc_version.is_none_or(|version| version == x.version()))
                     .collect();
 
-                let binary = versions.into_iter().next_back().expect("Can't be empty");
+                let Some(binary) = versions.into_iter().next_back() else {
+                    let message = if let Some(v) = &_resolc_version {
+                        format!("`resolc` v{v} doesn't exist")
+                    } else {
+                        format!("No `resolc` versions available.")
+                    };
+                    return Err(SolcError::Message(message));
+                };
 
                 let binary_info = match binary {
                     Binary::Remote(binary_info) => binary_info,


### PR DESCRIPTION
return correct error when `resolc` version doesn't exist
Closes: https://github.com/paritytech/foundry-polkadot/issues/126