### PR TITLE
[issues/136] - Added revive version to compiler metadata output

### DIFF
--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -47,17 +47,26 @@ pub struct ResolcContract {
 impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
     fn from(contract: ResolcContract) -> Self {
         let meta = match contract.metadata.as_ref() {
-            Some(meta) => match meta {
-                serde_json::Value::Object(map) => {
-                    if let Some(meta) = map.get("solc_metadata") {
-                        serde_json::from_value::<LosslessMetadata>(meta.clone()).ok()
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            },
-            None => Default::default(),
+            Some(serde_json::Value::Object(map)) => {
+                map.get("solc_metadata")
+                    .and_then(|solc_metadata| serde_json::from_value::<LosslessMetadata>(solc_metadata.clone()).ok())
+                    .map(|mut solc_metadata| {
+                        // Extract and inject revive compiler information if available.
+                        if let (Some(revive_version), Some(solc_version)) = (
+                            map.get("revive_version").and_then(|v| v.as_str()),
+                            map.get("solc_version").and_then(|v| v.as_str())
+                        ) {
+                            // Update version and regenerate raw metadata.
+                            solc_metadata.metadata.compiler.version = format!("{{\"revive\":\"{}\", \"solc\":\"{}\"}}", revive_version, solc_version);
+
+                            if let Ok(raw_metadata) = serde_json::to_string(&solc_metadata.metadata) {
+                                solc_metadata.raw_metadata = raw_metadata;
+                            }
+                        }
+                        solc_metadata
+                    })
+            }
+            _ => None,
         };
 
         Self {
@@ -73,5 +82,116 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
             ir_optimized: contract.ir_optimized,
             ir_optimized_ast: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_compilers_artifacts_solc::Contract;
+    use serde_json::json;
+
+    fn create_test_solc_metadata() -> String {
+        r#"{
+            "compiler": {
+                "version": "0.8.29+commit.ab55807c"
+            },
+            "language": "Solidity",
+            "output": {
+                "abi": [],
+                "devdoc": {"kind": "dev", "methods": {}, "version": 1},
+                "userdoc": {"kind": "user", "methods": {}, "version": 1}
+            },
+            "settings": {
+                "compilationTarget": {"src/Counter.sol": "Counter"},
+                "evmVersion": "cancun",
+                "libraries": {},
+                "metadata": {"bytecodeHash": "none"},
+                "optimizer": {
+                    "details": {
+                        "constantOptimizer": false,
+                        "cse": false,
+                        "deduplicate": false,
+                        "inliner": false,
+                        "jumpdestRemover": false,
+                        "orderLiterals": false,
+                        "peephole": false,
+                        "simpleCounterForLoopUncheckedIncrement": true,
+                        "yul": false
+                    },
+                    "runs": 200
+                },
+                "remappings": [":forge-std/=lib/forge-std/src/"]
+            },
+            "sources": {
+                "src/Counter.sol": {
+                    "keccak256": "0x09277f949d59a9521708c870dc39c2c434ad8f86a5472efda6a732ef728c0053",
+                    "license": "UNLICENSED",
+                    "urls": [
+                        "bzz-raw://94cd5258357da018bf911aeda60ed9f5b130dce27445669ee200313cd3389200",
+                        "dweb:/ipfs/QmNbEfWAqXCtfQpk6u7TpGa8sTHXFLpUz7uebz2FVbchSC"
+                    ]
+                }
+            },
+            "version": 1
+        }"#.to_string()
+    }
+
+    fn create_resolc_contract(metadata: Option<serde_json::Value>) -> ResolcContract {
+        ResolcContract {
+            abi: None,
+            metadata,
+            devdoc: None,
+            userdoc: None,
+            storage_layout: None,
+            evm: None,
+            ir: None,
+            ir_optimized: None,
+            hash: None,
+            factory_dependencies: None,
+            missing_libraries: None,
+        }
+    }
+
+    #[test]
+    fn test_from_resolc_contract_with_revive_metadata() {
+        let metadata = json!({
+            "solc_metadata": create_test_solc_metadata(),
+            "revive_version": "0.2.0+commit.e94432e.llvm-18.1.8",
+            "solc_version": "0.8.29+commit.ab55807c.Darwin.appleclang"
+        });
+
+        let contract: Contract = create_resolc_contract(Some(metadata)).into();
+
+        let metadata = contract.metadata.expect("metadata should be present");
+        assert_eq!(
+            metadata.metadata.compiler.version,
+            r#"{"revive":"0.2.0+commit.e94432e.llvm-18.1.8", "solc":"0.8.29+commit.ab55807c.Darwin.appleclang"}"#
+        );
+    }
+
+    #[test]
+    fn test_from_resolc_contract_without_revive_metadata() {
+        let metadata = json!({
+            "solc_metadata": create_test_solc_metadata()
+        });
+
+        let contract: Contract = create_resolc_contract(Some(metadata)).into();
+
+        let metadata = contract.metadata.expect("metadata should be present");
+        assert_eq!(metadata.metadata.compiler.version, "0.8.29+commit.ab55807c");
+    }
+
+    #[test]
+    fn test_from_resolc_contract_with_partial_revive_metadata() {
+        let metadata = json!({
+            "solc_metadata": create_test_solc_metadata(),
+            "revive_version": "0.2.0+commit.e94432e.llvm-18.1.8"
+        });
+
+        let contract: Contract = create_resolc_contract(Some(metadata)).into();
+
+        let metadata = contract.metadata.expect("metadata should be present");
+        assert_eq!(metadata.metadata.compiler.version, "0.8.29+commit.ab55807c");
     }
 }

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -86,3 +86,80 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_solc_metadata(version: &str, revive_version: Option<&str>) -> serde_json::Value {
+        let meta = json!({
+            "compiler": { "version": version },
+            "language": "Solidity",
+            "output": { "abi": [], "evm": { "bytecode": { "object": "0x" } } },
+            "settings": { "compilationTarget": {}, "evmVersion": "paris", "libraries": {}, "metadata": {}, "optimizer": {}, "remappings": [] },
+            "sources": {},
+            "version": 1
+        });
+        let solc_metadata_string = serde_json::to_string(&meta).unwrap();
+        match revive_version {
+            Some(revive) => json!({ "solc_metadata": solc_metadata_string, "revive_version": revive }),
+            None => json!({ "solc_metadata": solc_metadata_string }),
+        }
+    }
+
+    fn make_contract(metadata: Option<serde_json::Value>) -> ResolcContract {
+        ResolcContract {
+            abi: Some(JsonAbi::default()),
+            metadata,
+            devdoc: Some(DevDoc::default()),
+            userdoc: Some(UserDoc::default()),
+            storage_layout: Some(StorageLayout::default()),
+            evm: Some(ResolcEVM::default()),
+            ir: Some("test_ir".to_string()),
+            ir_optimized: Some("test_ir_optimized".to_string()),
+            hash: Some("test_hash".to_string()),
+            factory_dependencies: None,
+            missing_libraries: None,
+        }
+    }
+
+    #[test]
+    fn conversion_without_metadata() {
+        let contract = make_contract(None);
+        let solc_contract: foundry_compilers_artifacts_solc::Contract = contract.into();
+
+        assert!(solc_contract.metadata.is_none());
+    }
+
+    #[test]
+    fn conversion_with_metadata_and_versions() {
+        // No revive_version
+        let contract = make_contract(Some(make_solc_metadata("0.8.19", None)));
+        let solc_contract: foundry_compilers_artifacts_solc::Contract = contract.into();
+
+        assert_eq!(solc_contract.metadata.as_ref().unwrap().metadata.compiler.version, "0.8.19");
+
+        assert!(!solc_contract.metadata.as_ref().unwrap().metadata.compiler.additional_information.contains_key("revive_version"));
+
+        // With revive_version
+        let contract = make_contract(Some(make_solc_metadata("0.8.19", Some("0.1.0-dev.13"))));
+        let solc_contract: foundry_compilers_artifacts_solc::Contract = contract.into();
+        let meta = solc_contract.metadata.unwrap();
+
+        assert_eq!(meta.metadata.compiler.version, "0.8.19");
+        assert_eq!(meta.metadata.compiler.additional_information["revive_version"], json!("0.1.0-dev.13"));
+    }
+
+    #[test]
+    fn conversion_with_different_compiler_versions() {
+        let contract1 = make_contract(Some(make_solc_metadata("0.8.19", Some("0.1.0-dev.13"))));
+        let contract2 = make_contract(Some(make_solc_metadata("0.8.25", Some("0.1.0-dev.15"))));
+
+        let solc_contract1: foundry_compilers_artifacts_solc::Contract = contract1.into();
+        let solc_contract2: foundry_compilers_artifacts_solc::Contract = contract2.into();
+
+        assert_eq!(solc_contract1.metadata.as_ref().unwrap().metadata.compiler.version, "0.8.19");
+        assert_eq!(solc_contract2.metadata.as_ref().unwrap().metadata.compiler.version, "0.8.25");
+    }
+}

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -54,12 +54,15 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
                         // Extract and inject revive compiler information if available.
                         if let (Some(revive_version), Some(solc_version)) = (
                             map.get("revive_version").and_then(|v| v.as_str()),
-                            map.get("solc_version").and_then(|v| v.as_str())
+                            map.get("solc_version").and_then(|v| v.as_str()),
                         ) {
                             // Update version and regenerate raw metadata.
-                            solc_metadata.metadata.compiler.version = format!("{{\"revive\":\"{}\", \"solc\":\"{}\"}}", revive_version, solc_version);
+                            solc_metadata.metadata.compiler.version = format!(
+                                "{{\"revive\":\"{revive_version}\", \"solc\":\"{solc_version}\"}}"
+                            );
 
-                            if let Ok(raw_metadata) = serde_json::to_string(&solc_metadata.metadata) {
+                            if let Ok(raw_metadata) = serde_json::to_string(&solc_metadata.metadata)
+                            {
                                 solc_metadata.raw_metadata = raw_metadata;
                             }
                         }

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -49,7 +49,9 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
         let meta = match contract.metadata.as_ref() {
             Some(serde_json::Value::Object(map)) => {
                 map.get("solc_metadata")
-                    .and_then(|solc_metadata| serde_json::from_value::<LosslessMetadata>(solc_metadata.clone()).ok())
+                    .and_then(|solc_metadata| {
+                        serde_json::from_value::<LosslessMetadata>(solc_metadata.clone()).ok()
+                    })
                     .map(|mut solc_metadata| {
                         // Extract and inject revive compiler information if available.
                         if let (Some(revive_version), Some(solc_version)) = (

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -103,7 +103,9 @@ mod tests {
         });
         let solc_metadata_string = serde_json::to_string(&meta).unwrap();
         match revive_version {
-            Some(revive) => json!({ "solc_metadata": solc_metadata_string, "revive_version": revive }),
+            Some(revive) => {
+                json!({ "solc_metadata": solc_metadata_string, "revive_version": revive })
+            }
             None => json!({ "solc_metadata": solc_metadata_string }),
         }
     }
@@ -140,7 +142,14 @@ mod tests {
 
         assert_eq!(solc_contract.metadata.as_ref().unwrap().metadata.compiler.version, "0.8.19");
 
-        assert!(!solc_contract.metadata.as_ref().unwrap().metadata.compiler.additional_information.contains_key("revive_version"));
+        assert!(!solc_contract
+            .metadata
+            .as_ref()
+            .unwrap()
+            .metadata
+            .compiler
+            .additional_information
+            .contains_key("revive_version"));
 
         // With revive_version
         let contract = make_contract(Some(make_solc_metadata("0.8.19", Some("0.1.0-dev.13"))));
@@ -148,7 +157,10 @@ mod tests {
         let meta = solc_contract.metadata.unwrap();
 
         assert_eq!(meta.metadata.compiler.version, "0.8.19");
-        assert_eq!(meta.metadata.compiler.additional_information["revive_version"], json!("0.1.0-dev.13"));
+        assert_eq!(
+            meta.metadata.compiler.additional_information["revive_version"],
+            json!("0.1.0-dev.13")
+        );
     }
 
     #[test]

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -54,19 +54,16 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
                     })
                     .map(|mut solc_metadata| {
                         // Extract and inject revive compiler information if available.
-                        if let (Some(revive_version), Some(solc_version)) = (
-                            map.get("revive_version").and_then(|v| v.as_str()),
-                            map.get("solc_version").and_then(|v| v.as_str()),
-                        ) {
-                            // Update version and regenerate raw metadata.
-                            solc_metadata.metadata.compiler.version = format!(
-                                "{{\"revive\":\"{revive_version}\", \"solc\":\"{solc_version}\"}}"
+                        if let Some(revive_version) =
+                            map.get("revive_version").and_then(|v| v.as_str())
+                        {
+                            solc_metadata.metadata.compiler.additional_information.insert(
+                                "revive_version".to_string(),
+                                serde_json::Value::String(revive_version.to_string()),
                             );
 
-                            if let Ok(raw_metadata) = serde_json::to_string(&solc_metadata.metadata)
-                            {
-                                solc_metadata.raw_metadata = raw_metadata;
-                            }
+                            solc_metadata.raw_metadata =
+                                serde_json::to_string(&solc_metadata.metadata).unwrap();
                         }
                         solc_metadata
                     })
@@ -87,116 +84,5 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
             ir_optimized: contract.ir_optimized,
             ir_optimized_ast: None,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use foundry_compilers_artifacts_solc::Contract;
-    use serde_json::json;
-
-    fn create_test_solc_metadata() -> String {
-        r#"{
-            "compiler": {
-                "version": "0.8.29+commit.ab55807c"
-            },
-            "language": "Solidity",
-            "output": {
-                "abi": [],
-                "devdoc": {"kind": "dev", "methods": {}, "version": 1},
-                "userdoc": {"kind": "user", "methods": {}, "version": 1}
-            },
-            "settings": {
-                "compilationTarget": {"src/Counter.sol": "Counter"},
-                "evmVersion": "cancun",
-                "libraries": {},
-                "metadata": {"bytecodeHash": "none"},
-                "optimizer": {
-                    "details": {
-                        "constantOptimizer": false,
-                        "cse": false,
-                        "deduplicate": false,
-                        "inliner": false,
-                        "jumpdestRemover": false,
-                        "orderLiterals": false,
-                        "peephole": false,
-                        "simpleCounterForLoopUncheckedIncrement": true,
-                        "yul": false
-                    },
-                    "runs": 200
-                },
-                "remappings": [":forge-std/=lib/forge-std/src/"]
-            },
-            "sources": {
-                "src/Counter.sol": {
-                    "keccak256": "0x09277f949d59a9521708c870dc39c2c434ad8f86a5472efda6a732ef728c0053",
-                    "license": "UNLICENSED",
-                    "urls": [
-                        "bzz-raw://94cd5258357da018bf911aeda60ed9f5b130dce27445669ee200313cd3389200",
-                        "dweb:/ipfs/QmNbEfWAqXCtfQpk6u7TpGa8sTHXFLpUz7uebz2FVbchSC"
-                    ]
-                }
-            },
-            "version": 1
-        }"#.to_string()
-    }
-
-    fn create_resolc_contract(metadata: Option<serde_json::Value>) -> ResolcContract {
-        ResolcContract {
-            abi: None,
-            metadata,
-            devdoc: None,
-            userdoc: None,
-            storage_layout: None,
-            evm: None,
-            ir: None,
-            ir_optimized: None,
-            hash: None,
-            factory_dependencies: None,
-            missing_libraries: None,
-        }
-    }
-
-    #[test]
-    fn test_from_resolc_contract_with_revive_metadata() {
-        let metadata = json!({
-            "solc_metadata": create_test_solc_metadata(),
-            "revive_version": "0.2.0+commit.e94432e.llvm-18.1.8",
-            "solc_version": "0.8.29+commit.ab55807c.Darwin.appleclang"
-        });
-
-        let contract: Contract = create_resolc_contract(Some(metadata)).into();
-
-        let metadata = contract.metadata.expect("metadata should be present");
-        assert_eq!(
-            metadata.metadata.compiler.version,
-            r#"{"revive":"0.2.0+commit.e94432e.llvm-18.1.8", "solc":"0.8.29+commit.ab55807c.Darwin.appleclang"}"#
-        );
-    }
-
-    #[test]
-    fn test_from_resolc_contract_without_revive_metadata() {
-        let metadata = json!({
-            "solc_metadata": create_test_solc_metadata()
-        });
-
-        let contract: Contract = create_resolc_contract(Some(metadata)).into();
-
-        let metadata = contract.metadata.expect("metadata should be present");
-        assert_eq!(metadata.metadata.compiler.version, "0.8.29+commit.ab55807c");
-    }
-
-    #[test]
-    fn test_from_resolc_contract_with_partial_revive_metadata() {
-        let metadata = json!({
-            "solc_metadata": create_test_solc_metadata(),
-            "revive_version": "0.2.0+commit.e94432e.llvm-18.1.8"
-        });
-
-        let contract: Contract = create_resolc_contract(Some(metadata)).into();
-
-        let metadata = contract.metadata.expect("metadata should be present");
-        assert_eq!(metadata.metadata.compiler.version, "0.8.29+commit.ab55807c");
     }
 }

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -11,7 +11,7 @@ use semver::Version;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
     path::{Path, PathBuf},
     str::FromStr,
@@ -1419,6 +1419,8 @@ impl FromStr for ModelCheckerSolver {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Compiler {
     pub version: String,
+    #[serde(flatten, skip_serializing_if = "HashMap::is_empty")]
+    pub additional_information: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Given that [`solc` compiler metadata](https://docs.soliditylang.org/en/latest/metadata.html) can have arbitrary format, addressing [issue](https://github.com/paritytech/foundry-polkadot/issues/136), the compiler.version now contains `{"revive":"0.2.0+...", "solc":"0.8.29+..."}` instead of just the original `solc` version, providing complete compiler information for both `revive` and `solc` compilers used in the compilation process.

- Added `revive_version` and `solc_version` to `compiler` field as JSON object;
- Replaced original `solc` version with structured `revive` / `solc` version mapping;