### PR TITLE
added factory dependencies for Resolc Compiler

### DIFF
--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -71,7 +71,9 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
             _ => None,
         };
 
-        Self {
+        let factory_deps = contract.factory_dependencies.unwrap_or_default();
+
+        let mut solc_contract = Self {
             abi: contract.abi,
             evm: contract.evm.map(Into::into),
             metadata: meta,
@@ -83,7 +85,18 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
             ewasm: None,
             ir_optimized: contract.ir_optimized,
             ir_optimized_ast: None,
+            extensions: foundry_compilers_artifacts_solc::Extensions::None,
+        };
+
+        // Populate extensions if we have resolc-specific data
+        if !factory_deps.is_empty() {
+            let resolc_extras = foundry_compilers_artifacts_solc::ResolcExtras {
+                factory_dependencies: factory_deps,
+            };
+            solc_contract.extensions = foundry_compilers_artifacts_solc::Extensions::Resolc(resolc_extras);
         }
+
+        solc_contract
     }
 }
 

--- a/crates/artifacts/resolc/src/contract.rs
+++ b/crates/artifacts/resolc/src/contract.rs
@@ -93,7 +93,8 @@ impl From<ResolcContract> for foundry_compilers_artifacts_solc::Contract {
             let resolc_extras = foundry_compilers_artifacts_solc::ResolcExtras {
                 factory_dependencies: factory_deps,
             };
-            solc_contract.extensions = foundry_compilers_artifacts_solc::Extensions::Resolc(resolc_extras);
+            solc_contract.extensions =
+                foundry_compilers_artifacts_solc::Extensions::Resolc(resolc_extras);
         }
 
         solc_contract

--- a/crates/artifacts/solc/src/configurable.rs
+++ b/crates/artifacts/solc/src/configurable.rs
@@ -1,7 +1,7 @@
 use crate::{
     Ast, CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
-    CompactDeployedBytecode, DevDoc, Extensions, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource,
-    Metadata, Offsets, SourceFile, StorageLayout, UserDoc,
+    CompactDeployedBytecode, DevDoc, Ewasm, Extensions, FunctionDebugData, GasEstimates,
+    GeneratedSource, Metadata, Offsets, SourceFile, StorageLayout, UserDoc,
 };
 use alloy_json_abi::JsonAbi;
 use serde::{Deserialize, Serialize};

--- a/crates/artifacts/solc/src/configurable.rs
+++ b/crates/artifacts/solc/src/configurable.rs
@@ -1,6 +1,6 @@
 use crate::{
     Ast, CompactBytecode, CompactContract, CompactContractBytecode, CompactContractBytecodeCow,
-    CompactDeployedBytecode, DevDoc, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource,
+    CompactDeployedBytecode, DevDoc, Extensions, Ewasm, FunctionDebugData, GasEstimates, GeneratedSource,
     Metadata, Offsets, SourceFile, StorageLayout, UserDoc,
 };
 use alloy_json_abi::JsonAbi;
@@ -59,6 +59,9 @@ pub struct ConfigurableContractArtifact {
     /// The identifier of the source file
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<u32>,
+    /// Extensions for additional compiler-specific information
+    #[serde(default, skip_serializing_if = "Extensions::is_none")]
+    pub extensions: Extensions,
 }
 
 impl ConfigurableContractArtifact {

--- a/crates/artifacts/solc/src/contract.rs
+++ b/crates/artifacts/solc/src/contract.rs
@@ -11,6 +11,32 @@ use alloy_primitives::Bytes;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap};
 
+/// Extensions for Contract to provide additional compiler-specific information
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
+pub enum Extensions {
+    /// No extensions
+    #[default]
+    None,
+    /// Resolc-specific extensions
+    Resolc(ResolcExtras),
+}
+
+/// Additional Resolc-specific information for solc Contract
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default, Hash)]
+pub struct ResolcExtras {
+    /// Factory dependencies for the contract.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub factory_dependencies: BTreeMap<String, String>,
+    // Future fields can be added here like factory_dependencies_unlinked
+}
+
+impl Extensions {
+    /// Returns true if extensions is None
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
 /// Represents a compiled solidity contract
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -44,6 +70,9 @@ pub struct Contract {
     pub ir_optimized: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ir_optimized_ast: Option<serde_json::Value>,
+    /// Extensions for additional compiler-specific information
+    #[serde(default, skip_serializing_if = "Extensions::is_none")]
+    pub extensions: Extensions,
 }
 
 impl<'a> From<&'a Contract> for CompactContractBytecodeCow<'a> {

--- a/crates/artifacts/vyper/src/output.rs
+++ b/crates/artifacts/vyper/src/output.rs
@@ -84,6 +84,7 @@ impl From<VyperContract> for solc_artifacts::Contract {
             ewasm: None,
             ir_optimized: None,
             ir_optimized_ast: None,
+            extensions: solc_artifacts::Extensions::None,
         }
     }
 }

--- a/crates/compilers/src/artifact_output/configurable.rs
+++ b/crates/compilers/src/artifact_output/configurable.rs
@@ -230,6 +230,7 @@ impl ArtifactOutput for ConfigurableArtifacts {
             ewasm,
             ir_optimized,
             ir_optimized_ast,
+            extensions,
         } = contract;
 
         if self.additional_values.metadata {
@@ -325,6 +326,7 @@ impl ArtifactOutput for ConfigurableArtifacts {
             id: source_file.as_ref().map(|s| s.id),
             ast: source_file.and_then(|s| s.ast.clone()),
             generated_sources: generated_sources.unwrap_or_default(),
+            extensions,
         }
     }
 


### PR DESCRIPTION
Added an optional factory_dependencies field (a BTreeMap<String, String>) to Contract and ConfigurableContractArtifact in the resolc, solc, and vyper crates, with serde defaults to avoid breaking existing artifacts.

Propagated this new field through all From<…> conversions so parsed contracts now carry factory‐dependency metadata.

Updated the ArtifactOutput logic in the compilers crate to include factory_dependencies in emitted artifacts.
